### PR TITLE
'nst0022, x11.50 Vulkan (XPLMInstance)'

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -137,34 +137,38 @@ static void drawroutes()
     drawroute=airport.routes;
     while (drawroute)
     {
-        if (drawroute->state.hasdataref)	/* Objects that use a per-route DataRef can't be batched */
-        {
+        // nst0022 batch does not work with XPLMInstanceSetPosition(),
+        //         instead, the following 'then' needs to be executed at all times
+
+        //if (drawroute->state.hasdataref)	/* Objects that use a per-route DataRef can't be batched */
+        //{
             /* Have to check draw range every frame since "now" isn't updated while sim paused */
             if (indrawrange(drawroute->drawinfo->x-view_x, drawroute->drawinfo->y-view_y, drawroute->drawinfo->z-view_z, drawroute->object.drawlod * lod_factor))
-                XPLMDrawObjects(drawroute->object.objref, 1, drawroute->drawinfo, is_night, 1);
+                //XPLMDrawObjects(drawroute->object.objref, 1, drawroute->drawinfo, is_night, 1); // nst0022
+                XPLMInstanceSetPosition(drawroute->instance_ref, drawroute->drawinfo, NULL);      // nst0022
 
             if (drawroute->next && drawroute->object.objref == drawroute->next->object.objref)
                 drawroute->next->state.hasdataref = -1;	/* propagate flag to all routes using this objref */
 
             drawroute=drawroute->next;
         }
-        else
-        {
-            route_t *route, *first = 0, *last = 0;
+        //else
+        //{
+        //    route_t *route, *first = 0, *last = 0;
 
-            for (route=drawroute; route && route->object.objref==drawroute->object.objref; route=route->next)
-                /* Have to check draw range every frame since "now" isn't updated while sim paused */
-                if (indrawrange(route->drawinfo->x-view_x, route->drawinfo->y-view_y, route->drawinfo->z-view_z, route->object.drawlod * lod_factor))
-                {
-                    if (!first) first = route;
-                    last = route;
-                }
+        //    for (route=drawroute; route && route->object.objref==drawroute->object.objref; route=route->next)
+        //        /* Have to check draw range every frame since "now" isn't updated while sim paused */
+        //        if (indrawrange(route->drawinfo->x-view_x, route->drawinfo->y-view_y, route->drawinfo->z-view_z, route->object.drawlod * lod_factor))
+        //        {
+        //            if (!first) first = route;
+        //            last = route;
+        //        }
 
-            if (first)
-                XPLMDrawObjects(drawroute->object.objref, 1 + last->drawinfo - first->drawinfo, first->drawinfo, is_night, 1);
+        //    if (first)
+        //        XPLMDrawObjects(drawroute->object.objref, 1 + last->drawinfo - first->drawinfo, first->drawinfo, is_night, 1);
 
-            drawroute=route;
-        }
+        //    drawroute=route;
+        //}
     }
 }
 
@@ -470,7 +474,7 @@ int drawcallback(XPLMDrawingPhase inPhase, int inIsBefore, void *inRefcon)
                     route->state.collision = iscollision(route, COLLISION_TIMEOUT);
                 }
             }
-            
+
             last_node = route->path + route->last_node;
             next_node = route->path + route->next_node;
 

--- a/src/groundtraffic.h
+++ b/src/groundtraffic.h
@@ -59,6 +59,7 @@
 #  include <GL/glu.h>
 #endif
 
+#define XPLM302	// nst0022 requires X-Plane 11.50 or later
 #define XPLM210	/* Requires X-Plane 10.0 or later */
 #define XPLM200
 #include "XPLMDataAccess.h"
@@ -69,6 +70,7 @@
 #include "XPLMProcessing.h"
 #include "XPLMScenery.h"
 #include "XPLMUtilities.h"
+#include "XPLMInstance.h"  // nst0022
 
 #include "bbox.h"
 
@@ -303,6 +305,7 @@ typedef struct route_t
     userref_t (*varrefs)[MAX_VAR];	/* Per-route var dataref */
     struct route_t *parent;	/* Points to head of a train */
     struct route_t *next;
+    XPLMInstanceRef *instance_ref; // nst0022
 } route_t;
 
 


### PR DESCRIPTION
I have changed the code to XPLMInstancing, which is mandatory for X-Plane 11.50 Vulkan.

As I am on Linux, I was not able to 'make' for Windows and Mac, but I tested the new coding in a separate configuration.

I have marked all changes with 'nst0022' in the source code.

On my machine, 5 GroundTraffic plugins work now:

Golden Gate Bridge
Oakland Bay Bridge
MisterX San Francisco (*1)
MisterX San Francisco cable cars (*1)
San Diego Coronado Bridge
____
(*1) One peculiarity: The original GroundTraffic.txt files caused X-Plane to crash at the first XPLMInstanceSetPosition attempt.
I needed to replace all objects, that had ANIM_begin/_end in their .obj file with their counterparts without ANIM_begin/_end. I first thought, that XPLMInstanceSetPosition cannot handle animated objects, but it worked well with Laminar's Instance Sample Code. Well ?