### PR TITLE
nst0022, x11.50 Vulkan (XPLMInstance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,30 @@ Windows 32 or 64 bit binary:
     vcvarsall [target]
     nmake -f Makefile.win
 
+This fork by nst0022 (2020-04-23)
+----
+
+I have changed the code from XPLMDrawObjects to XPLMInstancing, which is mandatory for X-Plane 11.50 Vulkan.
+
+As I am on Linux, I could not compile for Windows or Mac, but tested the changes in a separate configuration (64-bit Linux only).
+
+In the make files for Windows and Mac, XPSDK213 needs probably to be replaced by XPSDK302, like in the make file for Linux, but I did not want to touch these files, nor did I change the version number.
+
+I have marked all changes with 'nst0022' in the source code, which might be better readable than the diff here on GitHub.
+
+The plugin works (here) now for the following custom sceneries:
+
+- San Francisco Golden Gate Bridge
+- San Francisco Oakland Bay Bridge
+- San Francisco Airport Vehicles [1]
+- San Francisco Cable Cars and Ferries [1]
+- San Diego Coronado Bridge
+
+covering the GroundTraffic statements 'route', 'highway', and 'train'.
+
+I will not maintain the source code further on, because I have only a rudimentary understanding of what happens internally. This source code is an offer for scenery maintainers, who want to consider the changes for their own purposes.
+____
+[1] One peculiarity: In these two GroundTraffic.txt files, I had to replace all objects, that contained ANIM_begin/_end in their .obj files, which caused X-Plane to crash on first XPLMInstanceSetPosition, with their non-ANIM counter parts:
+1. for San Francisco Cable Cars and Ferries I duplicated Ferry_SFO.obj to Ferry_SFO_no_anim.obj and removed the animation
+2. for San Francisco Airport Vehicles I simply replaced all '/Active/' with '/' in GroundTraffic.txt
+Of course, these changes should only show that it works. What has to be done for the custom sceneries has to be determined by their respective authors.

--- a/src/Makefile.lin
+++ b/src/Makefile.lin
@@ -5,7 +5,7 @@
 
 include ../version.mak
 
-XPSDK=../../XPSDK213
+XPSDK=../../XPSDK302
 
 CC=gcc
 #BUILD=-g -DDEBUG

--- a/src/draw.c
+++ b/src/draw.c
@@ -137,34 +137,38 @@ static void drawroutes()
     drawroute=airport.routes;
     while (drawroute)
     {
-        if (drawroute->state.hasdataref)	/* Objects that use a per-route DataRef can't be batched */
-        {
+        // nst0022 batch does not work with XPLMInstanceSetPosition(),
+        //         instead, the following 'then' needs to be executed at all times
+
+        //if (drawroute->state.hasdataref)	/* Objects that use a per-route DataRef can't be batched */
+        //{
             /* Have to check draw range every frame since "now" isn't updated while sim paused */
             if (indrawrange(drawroute->drawinfo->x-view_x, drawroute->drawinfo->y-view_y, drawroute->drawinfo->z-view_z, drawroute->object.drawlod * lod_factor))
-                XPLMDrawObjects(drawroute->object.objref, 1, drawroute->drawinfo, is_night, 1);
+                //XPLMDrawObjects(drawroute->object.objref, 1, drawroute->drawinfo, is_night, 1); // nst0022
+                XPLMInstanceSetPosition(drawroute->instance_ref, drawroute->drawinfo, NULL);      // nst0022
 
             if (drawroute->next && drawroute->object.objref == drawroute->next->object.objref)
                 drawroute->next->state.hasdataref = -1;	/* propagate flag to all routes using this objref */
 
             drawroute=drawroute->next;
-        }
-        else
-        {
-            route_t *route, *first = 0, *last = 0;
+        //}
+        //else
+        //{
+        //    route_t *route, *first = 0, *last = 0;
 
-            for (route=drawroute; route && route->object.objref==drawroute->object.objref; route=route->next)
-                /* Have to check draw range every frame since "now" isn't updated while sim paused */
-                if (indrawrange(route->drawinfo->x-view_x, route->drawinfo->y-view_y, route->drawinfo->z-view_z, route->object.drawlod * lod_factor))
-                {
-                    if (!first) first = route;
-                    last = route;
-                }
+        //    for (route=drawroute; route && route->object.objref==drawroute->object.objref; route=route->next)
+        //        /* Have to check draw range every frame since "now" isn't updated while sim paused */
+        //        if (indrawrange(route->drawinfo->x-view_x, route->drawinfo->y-view_y, route->drawinfo->z-view_z, route->object.drawlod * lod_factor))
+        //        {
+        //            if (!first) first = route;
+        //            last = route;
+        //        }
 
-            if (first)
-                XPLMDrawObjects(drawroute->object.objref, 1 + last->drawinfo - first->drawinfo, first->drawinfo, is_night, 1);
+        //    if (first)
+        //        XPLMDrawObjects(drawroute->object.objref, 1 + last->drawinfo - first->drawinfo, first->drawinfo, is_night, 1);
 
-            drawroute=route;
-        }
+        //    drawroute=route;
+        //}
     }
 }
 
@@ -470,7 +474,7 @@ int drawcallback(XPLMDrawingPhase inPhase, int inIsBefore, void *inRefcon)
                     route->state.collision = iscollision(route, COLLISION_TIMEOUT);
                 }
             }
-            
+
             last_node = route->path + route->last_node;
             next_node = route->path + route->next_node;
 

--- a/src/groundtraffic.h
+++ b/src/groundtraffic.h
@@ -59,6 +59,7 @@
 #  include <GL/glu.h>
 #endif
 
+#define XPLM302	// nst0022 requires X-Plane 11.50 or later
 #define XPLM210	/* Requires X-Plane 10.0 or later */
 #define XPLM200
 #include "XPLMDataAccess.h"
@@ -69,6 +70,7 @@
 #include "XPLMProcessing.h"
 #include "XPLMScenery.h"
 #include "XPLMUtilities.h"
+#include "XPLMInstance.h"  // nst0022
 
 #include "bbox.h"
 
@@ -303,6 +305,7 @@ typedef struct route_t
     userref_t (*varrefs)[MAX_VAR];	/* Per-route var dataref */
     struct route_t *parent;	/* Points to head of a train */
     struct route_t *next;
+    XPLMInstanceRef *instance_ref; // nst0022
 } route_t;
 
 


### PR DESCRIPTION
(Sorry for this 2nd pull request, I had to fix some cut&paste errors)

I have made changes to accomodate X-Plane 11.50 Vulkan, namely using XPLMInstancing instead of XPLMDrawObjects.

As I am on Linux, I could not compile for Windows or Mac, but tested the changes in a separate configuration (64-bit Linux only).

The plugin works (here) now for the following custom sceneries:

• San Francisco Golden Gate Bridge
• San Francisco Oakland Bay Bridge
• San Francisco Airport Vehicles (*1)
• San Francisco Cable Cars and Ferries (*1)
• San Diego Coronado Bridge

covering the GroundTraffic statements 'route', 'highway', and 'train'.

______
(*1) One peculiarity: In these two GroundTraffic.txt files, I had to replace all objects, that contained ANIM_begin/_end in their .obj files, which caused X-Plane to crash on first XPLMInstanceSetPosition, with their non-ANUM counter parts. I first thought, that XPLMInstanceSetPosition cannot handle such active objects, but in worked fine in Laminar's Instancing Sample Code. Well (?)
